### PR TITLE
Drop requirement on removed unit tests job from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ defaults:
 jobs:
   verify-apps:
     name: Build apps
-    needs: unit-tests
     strategy:
       matrix:
         os_name: ["macOS"]


### PR DESCRIPTION
One-line change because the app building no longer builds on top of unit tests

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
