### PR TITLE
Update iOS metadata to reflect recent required keys.

### DIFF
--- a/{{ cookiecutter.formal_name }}/{{ cookiecutter.class_name }}/{{ cookiecutter.class_name }}-Info.plist
+++ b/{{ cookiecutter.formal_name }}/{{ cookiecutter.class_name }}/{{ cookiecutter.class_name }}-Info.plist
@@ -24,10 +24,6 @@
 	<string>{{ cookiecutter.build }}</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>armv7</string>
-	</array>
 	<key>UIRequiresFullScreen</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>
@@ -47,5 +43,12 @@
 	</array>
 	<key>MainModule</key>
 	<string>{{ cookiecutter.module_name }}</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict/>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
At some point in the recent past, Xcode has started requiring iOS apps to declare their scenes, even if you're not using scene based layout.

In addition, the armv7 device capability is now a no op (and would be misleading, even if it *was* valid).

This PR updates the app metadata to reflect these two changes.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
