### PR TITLE
Bump support revisions.

### DIFF
--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -9,11 +9,11 @@ app_packages_path = "{{ cookiecutter.class_name }}/app_packages"
 info_plist_path = "{{ cookiecutter.class_name }}/{{ cookiecutter.class_name }}-Info.plist"
 support_path = "Support"
 {{ {
-    "3.9": "support_revision = 14",
-    "3.10": "support_revision = 10",
-    "3.11": "support_revision = 5",
-    "3.12": "support_revision = 5",
-    "3.13": "support_revision = 2",
+    "3.9": "support_revision = 15",
+    "3.10": "support_revision = 11",
+    "3.11": "support_revision = 6",
+    "3.12": "support_revision = 6",
+    "3.13": "support_revision = 3",
 }.get(cookiecutter.python_version|py_tag, "") }}
 
 icon.20 = "{{ cookiecutter.class_name }}/Images.xcassets/AppIcon.appiconset/icon-20.png"


### PR DESCRIPTION
Bumps the support package to the versions that include the updated `platform.ios_ver()`/`sys.implementation._multiarch` sitepackage shim, required for compatibility with pip 24.3.

Fixes beeware/briefcase#2053.
 
Requires backport to 0.3.20 branch.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
