### PR TITLE
Use the direct path for slices, not an alias.

### DIFF
--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.xcodeproj/project.pbxproj
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.xcodeproj/project.pbxproj
@@ -235,7 +235,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\n\nmkdir -p \"$CODESIGNING_FOLDER_PATH/python/lib\"\nif [ \"$EFFECTIVE_PLATFORM_NAME\" = \"-iphonesimulator\" ]; then\n    echo \"Installing Python modules for iOS Simulator\"\n    rsync -au --delete \"$PROJECT_DIR/Support/Python.xcframework/iphonesimulator/lib/\" \"$CODESIGNING_FOLDER_PATH/python/lib/\" \n    rsync -au --delete \"$PROJECT_DIR/{{ cookiecutter.class_name }}/app_packages.iphonesimulator/\" \"$CODESIGNING_FOLDER_PATH/app_packages\" \nelse\n    echo \"Installing Python modules for iOS Device\"\n    rsync -au --delete \"$PROJECT_DIR/Support/Python.xcframework/iphoneos/lib/\" \"$CODESIGNING_FOLDER_PATH/python/lib\" \n    rsync -au --delete \"$PROJECT_DIR/{{ cookiecutter.class_name }}/app_packages.iphoneos/\" \"$CODESIGNING_FOLDER_PATH/app_packages\" \nfi\n";
+			shellScript = "set -e\n\nmkdir -p \"$CODESIGNING_FOLDER_PATH/python/lib\"\nif [ \"$EFFECTIVE_PLATFORM_NAME\" = \"-iphonesimulator\" ]; then\n    echo \"Installing Python modules for iOS Simulator\"\n    rsync -au --delete \"$PROJECT_DIR/Support/Python.xcframework/ios-arm64_x86_64-simulator/lib/\" \"$CODESIGNING_FOLDER_PATH/python/lib/\" \n    rsync -au --delete \"$PROJECT_DIR/{{ cookiecutter.class_name }}/app_packages.iphonesimulator/\" \"$CODESIGNING_FOLDER_PATH/app_packages\" \nelse\n    echo \"Installing Python modules for iOS Device\"\n    rsync -au --delete \"$PROJECT_DIR/Support/Python.xcframework/ios-arm64/lib/\" \"$CODESIGNING_FOLDER_PATH/python/lib\" \n    rsync -au --delete \"$PROJECT_DIR/{{ cookiecutter.class_name }}/app_packages.iphoneos/\" \"$CODESIGNING_FOLDER_PATH/app_packages\" \nfi\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */


### PR DESCRIPTION
Modifies the build script used to install the standard library to use the actual names of the XCframework slices, not aliases.

For historical reasons that I'm sure seemed like a good idea at the time, the iOS support packages added a symlink from `ios-arm64` to `iphoneos`, and from `ios-arm64_x86_64-simulator` to `iphonesimulator`. It turns out it isn't any harder to use the original name directly, which then allows us to simplify the support package.

The iOS testbed project in CPython already uses the actual slice names; so this is normalises to behavior that is consistent with the testbed.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
