### PR TITLE
Add processing of .pth files from "app_packages".

### DIFF
--- a/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/main.m
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/main.m
@@ -192,32 +192,32 @@ int main(int argc, char *argv[]) {
             module = PyImport_ImportModule("site");
             if (module == NULL) {
                 crash_dialog(@"Could not import site module");
-                exit(-8);
+                exit(-11);
             }
 
             module_attr = PyObject_GetAttrString(module, "addsitedir");
             if (module_attr == NULL || !PyCallable_Check(module_attr)) {
                 crash_dialog(@"Could not access site.addsitedir");
-                exit(-9);
+                exit(-12);
             }
 
             app_packages_path = PyUnicode_FromWideChar(app_packages_path_str, wcslen(app_packages_path_str));
             if (app_packages_path == NULL) {
                 crash_dialog(@"Could not convert app_packages path to unicode");
-                exit(-10);
+                exit(-13);
             }
             PyMem_RawFree(app_packages_path_str);
 
             method_args = Py_BuildValue("(O)", app_packages_path);
             if (method_args == NULL) {
                 crash_dialog(@"Could not create arguments for site.addsitedir");
-                exit(-11);
+                exit(-14);
             }
 
             result = PyObject_CallObject(module_attr, method_args);
             if (result == NULL) {
                 crash_dialog(@"Could not add app_packages directory using site.addsitedir");
-                exit(-12);
+                exit(-15);
             }
 
 

--- a/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/main.m
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/main.m
@@ -23,8 +23,10 @@ int main(int argc, char *argv[]) {
     NSString *path;
     NSString *traceback_str;
     wchar_t *wtmp_str;
+    wchar_t *app_packages_path_str;
     const char* app_module_str;
     const char* nslog_script;
+    PyObject *app_packages_path;
     PyObject *app_module;
     PyObject *module;
     PyObject *module_attr;
@@ -125,18 +127,6 @@ int main(int argc, char *argv[]) {
         }
         PyMem_RawFree(wtmp_str);
 
-        // Add the app_packages path
-        path = [NSString stringWithFormat:@"%@/app_packages", resourcePath, nil];
-        NSLog(@"- %@", path);
-        wtmp_str = Py_DecodeLocale([path UTF8String], NULL);
-        status = PyWideStringList_Append(&config.module_search_paths, wtmp_str);
-        if (PyStatus_Exception(status)) {
-            crash_dialog([NSString stringWithFormat:@"Unable to set app packages path: %s", status.err_msg, nil]);
-            PyConfig_Clear(&config);
-            Py_ExitStatusException(status);
-        }
-        PyMem_RawFree(wtmp_str);
-
         // Add the app path
         path = [NSString stringWithFormat:@"%@/app", resourcePath, nil];
         NSLog(@"- %@", path);
@@ -188,6 +178,48 @@ int main(int argc, char *argv[]) {
                     exit(ret);
                 }
             }
+
+
+            // Adding the app_packages as site directory.
+            //
+            // This adds app_packages to sys.path and executes any .pth
+            // files in that directory.
+            path = [NSString stringWithFormat:@"%@/app_packages", resourcePath, nil];
+            app_packages_path_str = Py_DecodeLocale([path UTF8String], NULL);
+
+            NSLog(@"Adding app_packages as site directory: %@", path);
+
+            module = PyImport_ImportModule("site");
+            if (module == NULL) {
+                crash_dialog(@"Could not import site module");
+                exit(-8);
+            }
+
+            module_attr = PyObject_GetAttrString(module, "addsitedir");
+            if (module_attr == NULL || !PyCallable_Check(module_attr)) {
+                crash_dialog(@"Could not access site.addsitedir");
+                exit(-9);
+            }
+
+            app_packages_path = PyUnicode_FromWideChar(app_packages_path_str, wcslen(app_packages_path_str));
+            if (app_packages_path == NULL) {
+                crash_dialog(@"Could not convert app_packages path to unicode");
+                exit(-10);
+            }
+            PyMem_RawFree(app_packages_path_str);
+
+            method_args = Py_BuildValue("(O)", app_packages_path);
+            if (method_args == NULL) {
+                crash_dialog(@"Could not create arguments for site.addsitedir");
+                exit(-11);
+            }
+
+            result = PyObject_CallObject(module_attr, method_args);
+            if (result == NULL) {
+                crash_dialog(@"Could not add app_packages directory using site.addsitedir");
+                exit(-12);
+            }
+
 
             // Start the app module.
             //


### PR DESCRIPTION
As described [here](https://github.com/beeware/briefcase/issues/2195#issuecomment-2727821874), the `app_packages` should be added via `site.addsitedir()` so that `.pth` files are executed correctly.

I tested it with a minimal example project I made for this: [pth-execution-checker](https://github.com/timrid/pth-execution-checker)

In contrast to my previous attempts with the .pth files on iOS (see [here](https://github.com/beeware/briefcase/pull/2173#issuecomment-2727096883)), now the output of a `print()` inside the .pth files also works, since `site.addsitedir()` is called after the initialization of the NSLog and not before.

Should fix https://github.com/beeware/briefcase/issues/2195, https://github.com/beeware/briefcase/issues/669 and https://github.com/beeware/briefcase/issues/381 for "ios xcode".

There are also a similar PRs for:
- "windows visualstudio": https://github.com/beeware/briefcase-windows-VisualStudio-template/pull/52 
- "linux flatpak": https://github.com/beeware/briefcase-linux-flatpak-template/pull/58
- "linux system": https://github.com/beeware/briefcase-linux-system-template/pull/36

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct