### PR TITLE
Use a consistent variable name for iOS configuration.

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -12,7 +12,7 @@
     "version": "1.0",
     "build": "1",
     "python_version": "3.X.0",
-    "iphoneos_deployment_target": "13.0",
+    "min_os_version": "13.0",
     "_copy_without_render": [
         ".gitignore",
         "*.png"

--- a/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/dylib-Info-template.plist
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/dylib-Info-template.plist
@@ -19,7 +19,7 @@
 		<string>iPhoneOS</string>
 	</array>
 	<key>MinimumOSVersion</key>
-	<string>{{ cookiecutter.iphoneos_deployment_target }}</string>
+	<string>{{ cookiecutter.min_os_version }}</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.xcodeproj/project.pbxproj
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.xcodeproj/project.pbxproj
@@ -314,7 +314,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "\"$(BUILT_PRODUCTS_DIR)/Python.framework/Headers\"";
-				IPHONEOS_DEPLOYMENT_TARGET = {{ cookiecutter.iphoneos_deployment_target }};
+				IPHONEOS_DEPLOYMENT_TARGET = {{ cookiecutter.min_os_version }};
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -366,7 +366,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "\"$(BUILT_PRODUCTS_DIR)/Python.framework/Headers\"";
-				IPHONEOS_DEPLOYMENT_TARGET = {{ cookiecutter.iphoneos_deployment_target }};
+				IPHONEOS_DEPLOYMENT_TARGET = {{ cookiecutter.min_os_version }};
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -384,7 +384,7 @@
 				GCC_PREFIX_HEADER = "{{ cookiecutter.class_name }}/{{ cookiecutter.class_name }}-Prefix.pch";
 				HEADER_SEARCH_PATHS = "\"$(BUILT_PRODUCTS_DIR)/Python.framework/Headers\"";
 				INFOPLIST_FILE = "{{ cookiecutter.class_name }}/{{ cookiecutter.class_name }}-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = {{ cookiecutter.iphoneos_deployment_target }};
+				IPHONEOS_DEPLOYMENT_TARGET = {{ cookiecutter.min_os_version }};
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -407,7 +407,7 @@
 				GCC_PREFIX_HEADER = "{{ cookiecutter.class_name }}/{{ cookiecutter.class_name }}-Prefix.pch";
 				HEADER_SEARCH_PATHS = "\"$(BUILT_PRODUCTS_DIR)/Python.framework/Headers\"";
 				INFOPLIST_FILE = "{{ cookiecutter.class_name }}/{{ cookiecutter.class_name }}-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = {{ cookiecutter.iphoneos_deployment_target }};
+				IPHONEOS_DEPLOYMENT_TARGET = {{ cookiecutter.min_os_version }};
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
Modifies the template variable name used to configure the iOS deployment target to match the name used and documented in beeware/briefcase#2239.

This was previously configurable, but not documented as such, so there isn't technically a backwards compatibility concern; but I've added a backwards compatibility note to beeware/briefcase#2239 regardless.

Refs beeware/briefcase#2233.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
