### PR TITLE
Present traceback as separate NSLog entries to avoid hitting the 1023 bytes limit

### DIFF
--- a/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/main.m
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/main.m
@@ -335,7 +335,13 @@ int main(int argc, char *argv[]) {
  */
 void crash_dialog(NSString *details) {
     NSLog(@"Application has crashed!");
-    NSLog(@"========================\n%@", details);
+    NSLog(@"========================");
+
+    NSArray *lines = [details componentsSeparatedByString:@"\n"];
+    for (NSString *line in lines) {
+        NSLog(@"%@", line);
+    }
+
     // TODO - acutally make this a dialog
     // NSString *full_message = [NSString stringWithFormat:@"An unexpected error occurred.\n%@", details];
     // // Create a stack trace dialog


### PR DESCRIPTION
Without this change, if a Python traceback is longer than 1020 bytes, the rest of it is truncated with a 3-byte `<…>` ellipsis at the end. This makes it hard to debug what actually happened as the exception message is at the bottom of the traceback.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
