### PR TITLE
Set the locale on app startup.

### DIFF
--- a/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/main.m
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/main.m
@@ -38,6 +38,10 @@ int main(int argc, char *argv[]) {
     PyObject *systemExit_code;
 
     @autoreleasepool {
+        // iOS doesn't export an LANG environment variable; that variable is
+        // needed to set the locale correctly on startup.
+        setenv("LANG", [[NSString stringWithFormat:@"%@.UTF-8", NSLocale.currentLocale.localeIdentifier] UTF8String], 1);
+
         NSString *resourcePath = [[NSBundle mainBundle] resourcePath];
 
         // Generate an isolated Python configuration.
@@ -49,6 +53,8 @@ int main(int argc, char *argv[]) {
         // Enforce UTF-8 encoding for stderr, stdout, file-system encoding and locale.
         // See https://docs.python.org/3/library/os.html#python-utf-8-mode.
         preconfig.utf8_mode = 1;
+        // Ensure the locale is set (isolated interpreters won't by default)
+        preconfig.configure_locale = 1;
         // Don't buffer stdio. We want output to appears in the log immediately
         config.buffered_stdio = 0;
         // Don't write bytecode; we can't modify the app bundle


### PR DESCRIPTION
Fixes #57.

Ensures that the LANG environment variable is set on application startup, and that the locale is configured on interpreter startup (which isn't the default for an isolated environment).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
