### PR TITLE
Bump pre-commit-hooks from v5.0.0 to v6.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
       - id: check-json


### PR DESCRIPTION
Bumps `pre-commit` hook for `pre-commit-hooks` from v5.0.0 to v6.0.0 and ran the update against the repo.