### PR TITLE
Bump Python 3.13 and 3.14 support packages

### DIFF
--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -12,8 +12,8 @@ support_path = "Support"
     "3.10": "support_revision = 12",
     "3.11": "support_revision = 7",
     "3.12": "support_revision = 7",
-    "3.13": "support_revision = 10",
-    "3.14": "support_revision = 6",
+    "3.13": "support_revision = 12",
+    "3.14": "support_revision = 8",
 }.get(cookiecutter.python_version|py_tag, "") }}
 
 icon.20 = "{{ cookiecutter.class_name }}/Images.xcassets/AppIcon.appiconset/icon-20.png"


### PR DESCRIPTION
Bump the 3.13 and 3.14 support packages after the release of 3.13.8 and 3.14.0.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
