### PR TITLE
Ensure end-of-application object lifecycle is clean

### DIFF
--- a/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/main.m
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/main.m
@@ -303,9 +303,14 @@ int main(int argc, char *argv[]) {
             ret = -7;
         }
         @finally {
-            Py_Finalize();
+            // Force a full GC pass while the interpreter is alive and a pool is
+            // in place, so Python drops any ObjC references and anything
+            // autoreleased lands in this pool.
+            PyGC_Collect();
         }
     }
+    // Autorelease pool is drained; any Python -dealloc has run against a live interpreter.
+    Py_Finalize();
 
     exit(ret);
     return ret;


### PR DESCRIPTION
If a Toga object is created, but not added to a layout, it creates a number of cyclic object references. When the application exits, these references are garbage collected. Rubicon deallocates those objects by marking them for autorelease, with a closure (through WrappedPyObject) to ensure that the Python object is also dropped.

When the autorelease pool exits, any object that is referenced by Python will be cleaned up via the closure - but the current code invokes Py_Finalize() inside the autorelease pool, so the Python interpreter has already shut down when the final ObjC objects are released. This causes a segfault because a non-existent Python interpreter is used in deallocation calls.

Refs beeware/briefcase-macOS-Xcode-template#134. It's much less of an issue on iOS because an app doesn't ever really "exit", but to ensure we're catching the edge case of a crash on actual app exit, it's worth maintaining parity.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by: Claude Opus 5
