### PR TITLE
Move the minimum iOS version from 13.0 to 15.0

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -12,7 +12,7 @@
     "version": "1.0",
     "build": "1",
     "python_version": "3.X.0",
-    "min_os_version": "13.0",
+    "min_os_version": "15.0",
     "uses_non_exempt_encryption": false,
     "_copy_without_render": [
         ".gitignore",


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Change the minimum iOS version for Xcode
<!--- What problem does this change solve? -->
On newer versions of Xcode, including Xcode 27, the current version of 13.0 is now rejected and CLI-based automated builds fail, either the project needing to be manually updated or `briefcase open iOS` run to change the setting.

Also, on submission to App Store Connect/TestFlight Apple also complains and warns they won't support iOS < 15 shortly.

To fix both move the default forwards to iOS 15.

This reduces friction and removes some boilerplate (e.g. I was overriding this in CI to this point using `fastlane` plugins).

Notice that the GUI of Xcode 27 does not actually allow you to choose anything older than iOS 17, so we could choose that, but I expect we have a project policy to be conservative and tolerant of older versions of Xcode for as long as possible.

Tested using `template` argument in a Toga testbed with Xcode 27. 
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool

If approved a change note will need to follow in the `briefcase` repo.
